### PR TITLE
adding input plugin path for mono repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ https://docs.stackspot.com/en/home/set-up/customization/access-token
           client_key: ${{ secrets.CLIENT_KEY }}
           realm: ${{ secrets.REALM }}
           studio: studio_name
+          plugin_path: plugin_path #optional
 ```
 
 ## License

--- a/action.yml
+++ b/action.yml
@@ -14,6 +14,10 @@ inputs:
   studio:
     description: Studio name
     required: true
+  plugin_path:
+    description: Plugin Path
+    required: false
+    default: '.'    
 
 runs:
   using: "composite"
@@ -42,7 +46,10 @@ runs:
       shell: bash
       env:
         STUDIO: ${{ inputs.studio }}
-      run: stk publish plugin --studio $STUDIO
+        PLUGIN_PATH: ${{ inputs.plugin_path }}
+      run: |
+        cd $PLUGIN_PATH
+        stk publish plugin --studio $STUDIO
 
     - name: Show Log
       if: always()

--- a/action.yml
+++ b/action.yml
@@ -22,38 +22,40 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Download STK
-      shell: bash
-      run: curl -O https://stk.stackspot.com/installer/linux/stk.deb
-
-    - name: Install STK
+    - name: Setup STK CLI (beta)
       shell: bash
       run: |
-        sudo dpkg --install stk.deb
-        mv $HOME/.stk/bin/* /usr/local/bin
-        stk --version
-
-    - name: Login to StackSpot Account
-      env:
-        CLIENT_ID: ${{ inputs.client_id }}
-        CLIENT_KEY: ${{ inputs.client_key }}
-        REALM: ${{ inputs.realm }}
+        curl \
+          --fail \
+          --http2-prior-knowledge \
+          --location \
+          --output /tmp/stk.deb \
+          --silent \
+          --show-error \
+          --tlsv1.3 \
+          https://stk.stackspot.com/installer/linux/stk.deb
+        sudo dpkg --install /tmp/stk.deb || echo installed
+        rm --force /tmp/stk.deb
+    - name: Show STK CLI (beta) version
       shell: bash
-      run: stk login --client-id $CLIENT_ID --client-key $CLIENT_KEY --realm $REALM
-
+      run: $HOME/.stk/bin/stk --version
+    - name: Login StackSpot
+      shell: bash
+      run: |
+        $HOME/.stk/bin/stk login -id ${{ inputs.client_id }} -key ${{ inputs.client_key }} -r ${{ inputs.realm }}
+      env:
+        HTTP_ENABLE_DEBUG: true
+    - name: Checkout
+      uses: actions/checkout@v3
     - name: Publish plugin
       if: ${{ !contains(inputs.studio, 'UNPUBLISH_ACTION_TEST') }}
       shell: bash
-      env:
-        STUDIO: ${{ inputs.studio }}
-        PLUGIN_PATH: ${{ inputs.plugin_path }}
+      id: provision
       run: |
-        cd $PLUGIN_PATH
-        stk publish plugin --studio $STUDIO
-
-    - name: Show Log
-      if: always()
-      shell: bash
+        cd ${{ inputs.plugin_path }}
+        $HOME/.stk/bin/stk publish plugin --studio ${{ inputs.studio }}
+    - name: Show Error Log
+      shell: bash    
+      if: failure()
       run: |
-        cd $HOME/.stk/logs/
-        cat logs.log
+        cat $HOME/.stk/logs/*

--- a/action.yml
+++ b/action.yml
@@ -40,7 +40,7 @@ runs:
       shell: bash
       run: |
         sudo dpkg --install /tmp/stk.deb || echo installed
-        mv $HOME/.stk/bin/* /usr/local/bin
+        sudo mv $HOME/.stk/bin/* /usr/local/bin
         rm --force /tmp/stk.deb
 
     - name: Show STK CLI version

--- a/action.yml
+++ b/action.yml
@@ -22,7 +22,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Setup STK CLI (beta)
+    - name: Setup STK CLI
       shell: bash
       run: |
         curl \
@@ -36,7 +36,7 @@ runs:
           https://stk.stackspot.com/installer/linux/stk.deb
         sudo dpkg --install /tmp/stk.deb || echo installed
         rm --force /tmp/stk.deb
-    - name: Show STK CLI (beta) version
+    - name: Show STK CLI version
       shell: bash
       run: $HOME/.stk/bin/stk --version
     - name: Login StackSpot

--- a/action.yml
+++ b/action.yml
@@ -40,11 +40,12 @@ runs:
       shell: bash
       run: |
         sudo dpkg --install /tmp/stk.deb || echo installed
+        mv $HOME/.stk/bin/* /usr/local/bin
         rm --force /tmp/stk.deb
 
     - name: Show STK CLI version
       shell: bash
-      run: $HOME/.stk/bin/stk --version
+      run: stk --version
 
     - name: Login StackSpot
       shell: bash
@@ -53,7 +54,7 @@ runs:
         CLIENT_KEY: ${{ inputs.client_key }}
         REALM: ${{ inputs.realm }}
       run: |
-        $HOME/.stk/bin/stk login --client-id $CLIENT_ID --client-key $CLIENT_KEY --realm $REALM
+        stk login --client-id $CLIENT_ID --client-key $CLIENT_KEY --realm $REALM
 
     - name: Publish plugin
       if: ${{ !contains(inputs.studio, 'UNPUBLISH_ACTION_TEST') }}
@@ -63,7 +64,7 @@ runs:
         PLUGIN_PATH: ${{ inputs.plugin_path }}
       run: |
         cd $PLUGIN_PATH
-        $HOME/.stk/bin/stk publish plugin --studio $STUDIO
+        stk publish plugin --studio $STUDIO
 
     - name: Show Error Log
       shell: bash    

--- a/action.yml
+++ b/action.yml
@@ -63,7 +63,7 @@ runs:
         PLUGIN_PATH: ${{ inputs.plugin_path }}
       run: |
         cd $PLUGIN_PATH
-        stk publish plugin --studio $STUDIO
+        $HOME/.stk/bin/stk publish plugin --studio $STUDIO
 
     - name: Show Error Log
       shell: bash    

--- a/action.yml
+++ b/action.yml
@@ -22,7 +22,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Setup STK CLI
+    - name: Download STK CLI
       shell: bash
       run: |
         curl \
@@ -34,26 +34,37 @@ runs:
           --show-error \
           --tlsv1.3 \
           https://stk.stackspot.com/installer/linux/stk.deb
+        
+
+    - name: Install STK CLI
+      shell: bash
+      run: |
         sudo dpkg --install /tmp/stk.deb || echo installed
         rm --force /tmp/stk.deb
+
     - name: Show STK CLI version
       shell: bash
       run: $HOME/.stk/bin/stk --version
+
     - name: Login StackSpot
       shell: bash
-      run: |
-        $HOME/.stk/bin/stk login -id ${{ inputs.client_id }} -key ${{ inputs.client_key }} -r ${{ inputs.realm }}
       env:
-        HTTP_ENABLE_DEBUG: true
-    - name: Checkout
-      uses: actions/checkout@v3
+        CLIENT_ID: ${{ inputs.client_id }}
+        CLIENT_KEY: ${{ inputs.client_key }}
+        REALM: ${{ inputs.realm }}
+      run: |
+        $HOME/.stk/bin/stk login --client-id $CLIENT_ID --client-key $CLIENT_KEY --realm $REALM
+
     - name: Publish plugin
       if: ${{ !contains(inputs.studio, 'UNPUBLISH_ACTION_TEST') }}
       shell: bash
-      id: provision
+      env:
+        STUDIO: ${{ inputs.studio }}
+        PLUGIN_PATH: ${{ inputs.plugin_path }}
       run: |
-        cd ${{ inputs.plugin_path }}
-        $HOME/.stk/bin/stk publish plugin --studio ${{ inputs.studio }}
+        cd $PLUGIN_PATH
+        stk publish plugin --studio $STUDIO
+
     - name: Show Error Log
       shell: bash    
       if: failure()


### PR DESCRIPTION
Allows set a path from repository to publish a specific plugin in a repository that contains many plugins.
The new input is not required, so it will not affect current users
```
    - name: Publish Plugin
      uses: stack-spot/publish-plugin-action@feature/input-plugin-path
      with:
        client_id: ${{ secrets.CLIENT_ID }}
        client_key: ${{ secrets.CLIENT_KEY }}
        realm: ${{ secrets.REALM }}
        studio: my-studio
        plugin_path: pluginpath
```