### PR TITLE
exporting stk folder to environment variable `path`

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -40,8 +40,7 @@ runs:
       shell: bash
       run: |
         sudo dpkg --install /tmp/stk.deb || echo installed
-        sudo mv $HOME/.stk/bin/* /usr/local/bin
-        rm --force /tmp/stk.deb
+        export PATH=$HOME/.stk/bin
 
     - name: Show STK CLI version
       shell: bash


### PR DESCRIPTION
exporting stk folder to environment variable `path` to use stk command directly.