### PR TITLE
Error handling

### DIFF
--- a/.github/workflows/action-test.yml
+++ b/.github/workflows/action-test.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Run test action without publish
-        uses: stack-spot/publish-plugin-action@${{ github.ref }}
+        uses: stack-spot/publish-plugin-action@${{ github.ref_name }}
         with:
           client_id: ${{ secrets.CLIENT_ID }}
           client_key: ${{ secrets.CLIENT_KEY }}

--- a/.github/workflows/action-test.yml
+++ b/.github/workflows/action-test.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/action-test.yml
+++ b/.github/workflows/action-test.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Run test action without publish
-        uses: stack-spot/publish-plugin-action@${{ ref_name }}
+        uses: stack-spot/publish-plugin-action@fix/error-handling
         with:
           client_id: ${{ secrets.CLIENT_ID }}
           client_key: ${{ secrets.CLIENT_KEY }}

--- a/.github/workflows/action-test.yml
+++ b/.github/workflows/action-test.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Run test action without publish
-        uses: stack-spot/publish-plugin-action@fix/export-path
+        uses: stack-spot/publish-plugin-action@${{ github.ref }}
         with:
           client_id: ${{ secrets.CLIENT_ID }}
           client_key: ${{ secrets.CLIENT_KEY }}

--- a/.github/workflows/action-test.yml
+++ b/.github/workflows/action-test.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Run test action without publish
-        uses: stack-spot/publish-plugin-action@${{ github.ref_name }}
+        uses: stack-spot/publish-plugin-action@${{ ref_name }}
         with:
           client_id: ${{ secrets.CLIENT_ID }}
           client_key: ${{ secrets.CLIENT_KEY }}

--- a/action.yml
+++ b/action.yml
@@ -21,6 +21,7 @@ inputs:
 
 runs:
   using: "composite"
+  if: ${{ failure() }}
   steps:
     - name: Download STK CLI
       shell: bash
@@ -77,6 +78,5 @@ runs:
 
     - name: Show Error Log
       shell: bash    
-      if: failure()
       run: |
         cat $HOME/.stk/logs/*

--- a/action.yml
+++ b/action.yml
@@ -66,8 +66,6 @@ runs:
         STUDIO: ${{ inputs.studio }}
         PLUGIN_PATH: ${{ inputs.plugin_path }}
       run: |
-        ls -la
-        pwd
         cd $PLUGIN_PATH
         if [ -f "plugin.yaml" ] || [ -f "plugin.yml" ]; then
             $HOME/.stk/bin/stk publish plugin --studio $STUDIO
@@ -75,7 +73,6 @@ runs:
             $HOME/.stk/bin/stk publish action --studio $STUDIO
         else
           echo "No plugin.yaml or action.yaml found"
-          exit 1
         fi
 
     - name: Show Error Log
@@ -83,4 +80,4 @@ runs:
       if: failure()
       run: |
         cat $HOME/.stk/logs/*
-        exit 1;
+        exit 1

--- a/action.yml
+++ b/action.yml
@@ -73,6 +73,7 @@ runs:
             $HOME/.stk/bin/stk publish action --studio $STUDIO
         else
           echo "No plugin.yaml or action.yaml found"
+          exit 1
         fi
 
     - name: Show Error Log

--- a/action.yml
+++ b/action.yml
@@ -21,7 +21,6 @@ inputs:
 
 runs:
   using: "composite"
-  if: ${{ failure() }}
   steps:
     - name: Download STK CLI
       shell: bash
@@ -78,5 +77,7 @@ runs:
 
     - name: Show Error Log
       shell: bash    
+      if: failure()
       run: |
         cat $HOME/.stk/logs/*
+        exit 1

--- a/action.yml
+++ b/action.yml
@@ -66,6 +66,8 @@ runs:
         STUDIO: ${{ inputs.studio }}
         PLUGIN_PATH: ${{ inputs.plugin_path }}
       run: |
+        ls -la
+        pwd
         cd $PLUGIN_PATH
         if [ -f "plugin.yaml" ] || [ -f "plugin.yml" ]; then
             $HOME/.stk/bin/stk publish plugin --studio $STUDIO

--- a/action.yml
+++ b/action.yml
@@ -79,6 +79,5 @@ runs:
       shell: bash    
       if: ${{ failure() }}
       run: |
-        echo "Error: ${{ job.status.result }}"
         cat $HOME/.stk/logs/*
         exit 1

--- a/action.yml
+++ b/action.yml
@@ -80,3 +80,4 @@ runs:
       if: failure()
       run: |
         cat $HOME/.stk/logs/*
+        exit 1;

--- a/action.yml
+++ b/action.yml
@@ -80,4 +80,3 @@ runs:
       if: failure()
       run: |
         cat $HOME/.stk/logs/*
-        exit 1

--- a/action.yml
+++ b/action.yml
@@ -77,7 +77,8 @@ runs:
 
     - name: Show Error Log
       shell: bash    
-      if: failure()
+      if: ${{ failure() }}
       run: |
+        echo "Error: ${{ job.status.result }}"
         cat $HOME/.stk/logs/*
         exit 1


### PR DESCRIPTION
Issue:
Certain users within Itaú encountered an issue where, upon failure of a specific step, GitHub Actions erroneously displayed 
successful job completion.

![image](https://github.com/stack-spot/publish-plugin-action/assets/102608479/8b31cb92-2f8f-458f-b8a5-040f28fef67e)

Resolution:
Implemented a forced termination command to address instances where a job fails during the final step of the action. This ensures accurate reporting and prevents misleading success notifications for failed processes.

![image](https://github.com/stack-spot/publish-plugin-action/assets/102608479/7f768096-5aca-459d-af13-b75f691831ff)

